### PR TITLE
Remove initial dialog

### DIFF
--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -286,15 +286,6 @@ class iagl_utils(object):
 			if len([x for x in new_game_list_added if x])>0:
 				if xbmcvfs.exists(dat_file_cachename):
 					xbmcvfs.delete(dat_file_cachename)
-				if len([x for x in new_game_list_added if x])>2:
-					current_dialog = xbmcgui.Dialog()
-					ok_ret = current_dialog.ok('New Game Lists','New game lists are now available')
-					del current_dialog
-				else:
-					for ff in [x for x in new_game_list_added if x]:
-						current_dialog = xbmcgui.Dialog()
-						ok_ret = current_dialog.ok('New Game Lists','New game list %(dat_filename)s is now available' % {'dat_filename': ff})
-						del current_dialog
 
 	def get_list_cache_path(self):
 		current_path = os.path.join(self.get_addon_userdata_path(),self.list_cache_name)


### PR DESCRIPTION
This removes a dialog shown to the user when the add-on is first launched:

![screen shot 2018-07-28 at 6 38 48 pm](https://user-images.githubusercontent.com/531482/43985578-2cad3b24-9cbd-11e8-8c35-d4cce0a772d6.png)

There is no action for the user to take, so adding friction between them and their games doesn't seem worth it. This friction is especially important to avoid before the user plays their first game, because every dialog is a reason for the user to give up and never look back.

Good UX isn't about what you show, but what you hide.