### PR TITLE
Fix download progress overflow when file size is unknown

### DIFF
--- a/resources/lib/download.py
+++ b/resources/lib/download.py
@@ -529,7 +529,7 @@ class download(object):
 										current_size=int(xbmcgui.Window(self.dp_id).getProperty('current_size'))+len(chunk) #Get size of download combining all threads
 									else:
 										current_size=len(chunk)
-									percent_complete = int(100*current_size/((rom.get('filesize') or 0)+1)) #Calculate overall progress for downloading this file combining all threads
+									percent_complete = min(100, int(100*current_size/((rom.get('filesize') or 0)+1))) #Calculate overall progress for downloading this file combining all threads
 									xbmcgui.Window(self.dp_id).setProperty('current_size',str(current_size))
 									if xbmcgui.Window(self.dp_id).getProperty('start_time').isdigit():
 										bps_start = int(xbmcgui.Window(self.dp_id).getProperty('start_time'))/1000


### PR DESCRIPTION
## Summary

Fixes #346

When downloading games from collections where the `Content-Length` header is not provided by archive.org (e.g. ScummVM games served via `view_archive.php` for zip-inside-zip URLs), the download progress calculation overflows a 32-bit signed integer, causing the download to crash with `"signed integer is greater than maximum"`.

## Root cause

In `resources/lib/download.py` line 530:

```python
percent_complete = int(100*current_size/((rom.get('filesize') or 0)+1))
```

When `filesize` is `None`, this simplifies to `100 * current_size`, which exceeds the 32-bit signed integer maximum (~2.1 billion) for any download larger than ~21 MB. This value is passed to Kodi's `DialogProgress::update()` C++ method which expects 0-100, causing an integer overflow exception that aborts the download.

## Fix

Clamp `percent_complete` to the valid 0-100 range:

```python
percent_complete = min(100, int(100*current_size/((rom.get('filesize') or 0)+1)))
```

When `filesize` is known, the calculation works exactly as before. When unknown, the progress bar shows 100% during download while the download size and speed continue to display correctly via the text updates.

## Affected collections

This primarily affects the **ScummVM** game list, where all 471 games are sourced from a single 106 GB zip archive (`The_Complete_ScummVM_Collection_v2.0.zip`). Archive.org's `view_archive.php` endpoint does not return `Content-Length` headers, and the ScummVM game entries in the database have no `size` field populated.

### Note on missing sizes

The ScummVM game list is the only list where all games have an empty `size` field in the database, which also means users cannot see download sizes before starting a download:

![ScummVM game list with populated sizes](https://github.com/user-attachments/assets/cf0c014a-8d1c-44e8-baff-a147c39d70a3)

The screenshot above shows the list after manually populating sizes from archive.org's zip listing. Populating these sizes in the database would improve user experience and enable accurate progress reporting. The sizes are available from archive.org's zip contents listing endpoint.

## Testing

- Tested with Gabriel Knight 2 The Beast Within (2.8 GB) — previously crashed, now downloads successfully
- Tested with smaller ScummVM games — continue to work as before
- No impact on other game lists where `filesize` is properly set

## Environment

- Kodi 21.3 (Omega)
- IAGL v4.0.6
- Arch Linux